### PR TITLE
argument name typo in SLURMCluster() function

### DIFF
--- a/moseq2_pca/util.py
+++ b/moseq2_pca/util.py
@@ -255,7 +255,7 @@ def initialize_dask(nworkers=50, processes=4, memory='4GB', cores=2,
                                cores=cores,
                                memory=memory,
                                queue=queue,
-                               wall_time=wall_time,
+                               walltime=wall_time,
                                local_directory=cache_path)
 
         workers = cluster.start_workers(nworkers)


### PR DESCRIPTION
Found a bug trying initialize some dask workers in a jupyter notebook. The wall time for the workers was being set to the default 30:00, rather than the wall time I specified in `initialize_dask`. Looks like it was just a typo in the `SLURMCluster` function called in `util.py`.