### PR TITLE
upgrade joblib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     platforms=['mac', 'unix'],
     packages=find_packages(),
     install_requires=['h5py', 'matplotlib', 'scipy>=0.19',
-                      'tqdm', 'numpy==1.14.5', 'joblib==0.11',
+                      'tqdm', 'numpy==1.14.5', 'joblib==0.13.1',
                       'opencv-python', 'click', 'ruamel.yaml>=0.15.0',
                       'dask[complete]', 'chest', 'seaborn', 'dask_jobqueue>=0.3.0',
                       'scikit-image>=0.14', 'bokeh', 'psutil'],


### PR DESCRIPTION
Upgraded joblib, tested loading in moseq models saved with joblib `0.11`. Works without error.