### PR TITLE
Fix inconsistent overwrite message

### DIFF
--- a/moseq2_pca/helpers/wrappers.py
+++ b/moseq2_pca/helpers/wrappers.py
@@ -85,7 +85,7 @@ def train_pca_wrapper(input_dir, config_data, output_dir, output_file):
     # Edge Case: Handling pre-existing PCA file
     if not config_data.get('overwrite_pca_train', False):
         if exists(f'{save_file}.h5'):
-            click.echo(f'The file {save_file}.h5 already exists.\nWould you like to overwrite it? [y -> yes, else -> exit]\n')
+            click.echo(f'The file {save_file}.h5 already exists.\nWould you like to overwrite it? [y -> yes, n -> no]\n')
             ow = input()
             if ow.lower() != 'y':
                 return config_data
@@ -225,7 +225,7 @@ def apply_pca_wrapper(input_dir, config_data, output_dir, output_file):
     if not config_data.get('overwrite_pca_apply', False):
         if exists(f'{save_file}.h5'):
             click.echo(
-                f'The file {save_file}.h5 already exists.\nWould you like to overwrite it? [y -> yes, else -> exit]\n')
+                f'The file {save_file}.h5 already exists.\nWould you like to overwrite it? [y -> yes, n -> no]\n')
             ow = input()
             if ow.lower() != 'y':
                 return config_data


### PR DESCRIPTION
## Issue being fixed or feature implemented
Some overwrite messages in MoSeq says "[y -> yes, else -> exit]" and some says "[y -> yes, n-> no]". It may be better to a consistent message. Issue described in https://github.com/dattalab/moseq2-app/issues/135

## What was done?
I changed all the "[y -> yes, else -> exit]" to "[y -> yes, n-> no]".

## How Has This Been Tested?
Locally and CI. All passed.

## Breaking Changes
None


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
