### PR TITLE
fix: added python version limit to `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,6 @@ setup(
                       'click==7.0', 'ruamel.yaml==0.16.5', 'dask==2.19.0', 'bokeh==2.2.1',
                       'distributed==2.19.0', 'chest==0.2.3', 'seaborn==0.11.0', 'dask-jobqueue==0.7.0',
                       'scikit-image==0.16.2', 'psutil==5.6.7'],
-    python_requires='>=3.6',
+    python_requires='>=3.6,<3.8',
     entry_points={'console_scripts': ['moseq2-pca = moseq2_pca.cli:cli']}
 )


### PR DESCRIPTION
Issue described [here](https://github.com/dattalab/moseq2-app/issues/75).

## Issue being fixed or feature implemented
`moseq2-pca` has an inconsistent python version requirement from all the other repositories.


## How Has This Been Tested?
Locally and Travis

## What Was Done?
Added a maximum version limit of __`>3.8`__ to the `python_requires` section in the `setup.py` to match all the other MoSeq2 repositories.

## Breaking Changes
None

## Checklists
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
