### PR TITLE
fix: Skipped Apply-PCA computation causes incorrect index file or `KeyError`

### DIFF
--- a/moseq2_pca/gui.py
+++ b/moseq2_pca/gui.py
@@ -65,6 +65,7 @@ def apply_pca_command(progress_paths, output_file):
     -------
     (str): success string.
     '''
+
     # Get default CLI params
     default_params = {tmp.name: tmp.default for tmp in apply_pca.params if not tmp.required}
 
@@ -80,12 +81,16 @@ def apply_pca_command(progress_paths, output_file):
 
     config_data = apply_pca_wrapper(input_dir, config_data, output_dir, output_file)
 
-    with open(config_file, 'w') as f:
-        yaml.safe_dump(config_data, f)
+    success_str = ''
 
     index_params = read_yaml(index_file)
     if index_params:
-        index_params['pca_path'] = config_data['pca_file_scores']
+        if config_data.get('overwrite_pca_apply', False):
+            index_params['pca_path'] = config_data['pca_file_scores']
+            success_str = 'PCA Scores have been successfully computed.'
+        else:
+            config_data.pop('overwrite_pca_apply', None)
+            success_str = 'Preexisting PCA Scores have not been updated.'
 
         with open(index_file, 'w') as f:
             yaml.safe_dump(index_params, f)
@@ -93,7 +98,10 @@ def apply_pca_command(progress_paths, output_file):
     else:
         print('moseq2-index not found, did not update paths')
 
-    return 'PCA Scores have been successfully computed.'
+    with open(config_file, 'w') as f:
+        yaml.safe_dump(config_data, f)
+
+    return success_str
 
 
 def compute_changepoints_command(input_dir, progress_paths, output_file):

--- a/moseq2_pca/helpers/wrappers.py
+++ b/moseq2_pca/helpers/wrappers.py
@@ -228,6 +228,7 @@ def apply_pca_wrapper(input_dir, config_data, output_dir, output_file):
                 f'The file {save_file}.h5 already exists.\nWould you like to overwrite it? [y -> yes, n -> no]\n')
             ow = input()
             if ow.lower() != 'y':
+                config_data['overwrite_pca_apply'] = False
                 return config_data
 
     # Get path to trained PCA file to load PCs from


### PR DESCRIPTION
## Issue being fixed or feature implemented
- [Issue described here](https://github.com/dattalab/moseq2-app/issues/136).
- If a user has already computed the PCA Scores, runs the cell again and chooses to not overwrite the previous file, a `KeyError` is raised. Alternatively, if no error is raised, the index file `pca_path` is updated with an empty string value, causing `OSError`s down the line. Issue mentioned [here](https://github.com/dattalab/moseq2-app/issues/138).

## How Has This Been Tested?
Locally and Travis

## What Was Done?
- In the `apply_pca_wrapper()` function, I set `config_data['overwrite_pca_apply']` to `False`. This variable will be used in the `gui.py` function: `apply_pca_command()` to determine whether to overwrite the index file path.
    - It will avoid the `KeyError` because the `config_data` parameter `pca_file_scores` will only be referenced if the PCA Scores were computed.
    - The index file will be unchanged.

## Breaking Changes
None

## Checklists
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
