### PR TITLE
fix: flags gets written to config.yaml and users can't easily change it

### DIFF
--- a/moseq2_pca/util.py
+++ b/moseq2_pca/util.py
@@ -75,12 +75,14 @@ def command_with_config(config_file_param_name):
                         if param_defaults[param] != value:
                             ctx.params[param] = value
 
+                # removed flags
+                flag_list = ['missing_data', 'use_fft', 'verbose', 'from_end']
+                combined = {k:v for k,v in ctx.params.items() if k not in flag_list}
                 # combine params with config_params
-                config_data = {**config_data, **ctx.params}
+                config_data = {**config_data, **combined}
                 # write parameters to config_file
                 with open(config_file, 'w') as f:
                     yaml.safe_dump(config_data, f)
-
             return super(custom_command_class, self).invoke(ctx)
 
     return custom_command_class


### PR DESCRIPTION
## Issue being fixed or feature implemented
The new CLI writes all the parameters to `config.yaml` to keep track of all the parameters run. However, if the users have specified a flag, and the flag will be set to True in the `config.yaml` and users may not be aware of that when using the `config.yaml` later.

## What was done?
Instead of writing all the parameters used in the step to `config.yaml`, only non-flag parameters get written to the config.yaml. Flags specified in config.yaml won't get updated.

## How Has This Been Tested?
CI and locally


## Breaking Changes
NA


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
