### PR TITLE
chore: update links in download scripts

### DIFF
--- a/scripts/download_test_dataset.sh
+++ b/scripts/download_test_dataset.sh
@@ -1,2 +1,2 @@
-curl -L -o data.zip https://www.dropbox.com/sh/b0tpybq283a85ow/AABinnaFTGmUUcYOQ3GtwpRBa?dl=0 && unzip data.zip -d data
+curl -L -o data.zip https://www.dropbox.com/sh/ki8vu9iwapvsk5a/AADipJ4LpTDRQ76KlcxMbgoAa?dl=0 && unzip data.zip -d data
 rm data.zip


### PR DESCRIPTION
## Issue being fixed or feature implemented
Update links to download test data since Ayman's dropbox links will no longer be available.