### PR TITLE
chore: remove output related from config.yaml

### DIFF
--- a/moseq2_pca/util.py
+++ b/moseq2_pca/util.py
@@ -735,5 +735,7 @@ def combine_new_config(config_file, config_data):
         temp_config = yaml.safe_load(f)
     # combining config data with the existing config file
     config_data = {**temp_config, **config_data}
+    # ensure output_file and output_dir are not in config_data or reusing config for extraction will fail
+    config_data = {k:v for k, v in config_data.items() if k not in ('output_dir', 'output_file')}
     with open(config_file, 'w') as f:
         yaml.safe_dump(config_data, f)


### PR DESCRIPTION
## Issue being fixed or feature implemented
Remove output_dir and output_file in the config_data that gets written to the config.yaml file so if users reuse the config.yaml file for extraction, the output_dir won't be proc.

In both cli and notebook, output_dir for pca step is passed in so this change won't affect the PCA step output.


## What was done?
Remove output_dir and output_file from writing out to config.yaml.


## How Has This Been Tested?
Locally, O2, and CI


## Breaking Changes
NA


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
