### PR TITLE
fix: add dashboard address to scheduler options

### DIFF
--- a/moseq2_pca/util.py
+++ b/moseq2_pca/util.py
@@ -567,7 +567,7 @@ def initialize_dask(nworkers=50, processes=1, memory='4GB', cores=1,
                                queue=queue,
                                walltime=wall_time,
                                local_directory=cache_path,
-                               dashboard_address=dashboard_port,
+                               scheduler_options={'dashboard_address': dashboard_port},
                                **kwargs)
         client = Client(cluster)
     else:


### PR DESCRIPTION
## Issue being fixed or feature implemented
In the new dask version, dashboard_address is added to scheduler options.


## What was done?
Move the dashobard_address parameter in the dictionary in the scheduler option.


## How Has This Been Tested?
Locally, O2 and slurm.


## Breaking Changes
NA


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
